### PR TITLE
Support "replay-nonce" being empty

### DIFF
--- a/lib/ex_acme/request.ex
+++ b/lib/ex_acme/request.ex
@@ -148,6 +148,7 @@ defmodule ExAcme.Request do
   defp maybe_refresh_nonce(client, headers) do
     case List.keyfind(headers, "replay-nonce", 0) do
       {_, nonce} -> Agent.update(client, &Map.put(&1, :nonce, nonce))
+      _ -> client
     end
   end
 

--- a/lib/ex_acme/request.ex
+++ b/lib/ex_acme/request.ex
@@ -148,7 +148,7 @@ defmodule ExAcme.Request do
   defp maybe_refresh_nonce(client, headers) do
     case List.keyfind(headers, "replay-nonce", 0) do
       {_, nonce} -> Agent.update(client, &Map.put(&1, :nonce, nonce))
-      _ -> client
+      _ -> nil
     end
   end
 


### PR DESCRIPTION
When an error occurs during a request, its likely the "replay-nonce" will be empty.