### PR TITLE
feat: add support for Retry-After headers in ACME responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ ExAcme is a lightweight, developer-friendly Elixir library for interacting with 
 ## Missing
 
 - [Renewal information extension (DRAFT)](https://datatracker.ietf.org/doc/draft-ietf-acme-ari/)
-- Exposing `Retry-After` header information.
 
 ## Installation
 
@@ -117,9 +116,8 @@ for auth_url <- order.authorizations do
     # Trigger validation
     {:ok, _validated_challenge} = ExAcme.start_challenge_validation(challenge.url, account_key, MyAcme)
 
-    # Optionally, wait and verify the challenge status
-    :timer.sleep(5000)
-    {:ok, validated_challenge} = ExAcme.fetch_challenge(challenge.url, account_key, MyAcme)
+    # Poll for challenge completion with proper backoff handling
+    validated_challenge = poll_until_valid(challenge.url, account_key, MyAcme)
 
     if validated_challenge.status == "valid" do
       IO.puts("Challenge for #{authorization.identifier["value"]} validated successfully.")
@@ -174,6 +172,51 @@ case ExAcme.fetch_certificates(finalized_order.certificate_url, account_key, MyA
     IO.inspect(reason)
 end
 ```
+
+## Handling Retry-After Responses
+
+ExAcme surfaces `Retry-After` headers from ACME servers by returning `{:error, {:retry_after, seconds}}` when the server indicates you should wait before retrying. Here's how to implement proper polling with backoff:
+
+```elixir
+defp poll_until_valid(url, account_key, client, max_attempts \\ 10) do
+  poll_until_valid(url, account_key, client, max_attempts, 1)
+end
+
+defp poll_until_valid(_url, _account_key, _client, 0, _attempt) do
+  {:error, :max_attempts_reached}
+end
+
+defp poll_until_valid(url, account_key, client, max_attempts, attempt) do
+  case ExAcme.fetch_challenge(url, account_key, client) do
+    {:ok, challenge} ->
+      case challenge.status do
+        "valid" ->
+          {:ok, challenge}
+        "invalid" ->
+          {:error, {:challenge_failed, challenge}}
+        "pending" ->
+          # Wait a bit and retry
+          :timer.sleep(2000)
+          poll_until_valid(url, account_key, client, max_attempts - 1, attempt + 1)
+        "processing" ->
+          # Wait a bit and retry
+          :timer.sleep(1000)
+          poll_until_valid(url, account_key, client, max_attempts - 1, attempt + 1)
+      end
+
+    {:error, {:retry_after, seconds}} ->
+      # Server told us exactly how long to wait
+      IO.puts("Server requested retry after #{seconds} seconds")
+      :timer.sleep(seconds * 1000)
+      poll_until_valid(url, account_key, client, max_attempts - 1, attempt + 1)
+
+    {:error, reason} ->
+      {:error, reason}
+  end
+end
+```
+
+This pattern works for all fetch operations (`fetch_order/3`, `fetch_authorization/3`, `fetch_challenge/3`, etc.) and `start_challenge_validation/3`.
 
 ## License
 

--- a/lib/ex_acme.ex
+++ b/lib/ex_acme.ex
@@ -197,6 +197,7 @@ defmodule ExAcme do
   ## Returns
 
     - `{:ok, account}` - If the account is successfully fetched.
+    - `{:error, {:retry_after, seconds}}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the fetch operation.
   """
   @spec fetch_account(String.t(), ExAcme.AccountKey.t(), client()) :: {:ok, ExAcme.Account.t()} | {:error, any()}
@@ -216,6 +217,7 @@ defmodule ExAcme do
   ## Returns
 
     - `{:ok, authorization}` - If the authorization is successfully fetched.
+    - `{:error, {:retry_after, seconds}}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the fetch operation.
   """
   @spec fetch_authorization(String.t(), ExAcme.AccountKey.t(), client()) ::
@@ -260,6 +262,7 @@ defmodule ExAcme do
   ## Returns
 
     - `{:ok, challenge}` - If the challenge is successfully fetched.
+    - `{:error, {:retry_after, seconds}}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the fetch operation.
   """
   @spec fetch_challenge(String.t(), ExAcme.AccountKey.t(), client()) ::
@@ -280,6 +283,7 @@ defmodule ExAcme do
   ## Returns
 
     - `{:ok, order}` - If the order is successfully fetched.
+    - `{:error, {:retry_after, seconds}}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the fetch operation.
   """
   @spec fetch_order(String.t(), ExAcme.AccountKey.t(), client()) ::
@@ -457,6 +461,7 @@ defmodule ExAcme do
 
     - `{:ok, challenge}` - If the challenge validation request is successfully sent, returns the
       updated challenge information.
+    - `{:error, {:retry_after, seconds}}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the validation request.
   """
   @spec start_challenge_validation(String.t(), ExAcme.AccountKey.t(), client()) ::

--- a/test/ex_acme/request_test.exs
+++ b/test/ex_acme/request_test.exs
@@ -1,0 +1,43 @@
+defmodule ExAcme.RequestTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias ExAcme.Request
+
+  describe "parse_retry_after/1" do
+    test "parses valid integer seconds" do
+      assert Request.parse_retry_after("120") == {:ok, 120}
+      assert Request.parse_retry_after("0") == {:ok, 0}
+      assert Request.parse_retry_after("999") == {:ok, 999}
+    end
+
+    test "returns error for negative seconds" do
+      assert Request.parse_retry_after("-30") == :error
+    end
+
+    test "returns error for invalid integer format" do
+      assert Request.parse_retry_after("60.5") == :error
+      assert Request.parse_retry_after("abc") == :error
+      assert Request.parse_retry_after("") == :error
+      assert Request.parse_retry_after("60x") == :error
+    end
+
+    test "parses ISO8601 datetime format" do
+      future_time = DateTime.utc_now() |> DateTime.add(300, :second) |> DateTime.to_iso8601()
+      
+      assert {:ok, seconds} = Request.parse_retry_after(future_time)
+      assert seconds >= 299 and seconds <= 301
+    end
+
+    test "returns error for past datetime" do
+      past_time = DateTime.utc_now() |> DateTime.add(-300, :second) |> DateTime.to_iso8601()
+      
+      assert Request.parse_retry_after(past_time) == :error
+    end
+
+    test "returns error for invalid datetime format" do
+      assert Request.parse_retry_after("not-a-date") == :error
+      assert Request.parse_retry_after("2025-13-01T12:00:00Z") == :error
+    end
+  end
+end


### PR DESCRIPTION
Return `{:error, {:retry_after, seconds}}` when servers send `Retry-After` headers with 4xx/5xx responses to improve ergonomics for polling flows.

Changes:
- Extract and parse `Retry-After` headers (seconds or ISO8601 format)
- Surface retry information through all fetch functions
- Update documentation with proper backoff example

Improves compliance with RFC 8555 section 6.6 rate limiting guidelines.