### PR TITLE
feat!: accept structs in action functions instead of URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ for auth_url <- order.authorizations do
     setup_challenge(authorization.identifier["value"], value)
 
     # Trigger validation
-    {:ok, _validated_challenge} = ExAcme.start_challenge_validation(challenge.url, account_key, MyAcme)
+    {:ok, _validated_challenge} = ExAcme.start_challenge_validation(challenge, account_key, MyAcme)
 
     # Poll for challenge completion with proper backoff handling
     case poll_until_valid(challenge.url, account_key, MyAcme) do
@@ -156,7 +156,7 @@ private_key = X509.PrivateKey.new_ec(:secp256r1)
 csr = Order.to_csr(order, private_key)
 
 # Finalize the order by submitting the CSR
-case ExAcme.finalize_order(order.finalize_url, csr, account_key, MyAcme) do
+case ExAcme.finalize_order(order, csr, account_key, MyAcme) do
   {:ok, finalized_order} ->
     IO.puts("Order finalized successfully!")
     IO.inspect(finalized_order)

--- a/lib/ex_acme.ex
+++ b/lib/ex_acme.ex
@@ -303,11 +303,13 @@ defmodule ExAcme do
   end
 
   @doc """
-  Finalizes an order by sending a Certificate Signing Request (CSR) to the specified URL.
+  Finalizes an order by sending a Certificate Signing Request (CSR).
 
   ## Parameters
 
-    - `finalize_url` - The URL to finalize the order.
+    - `order` - The `ExAcme.Order` struct to finalize. Must have `url` and `finalize_url` fields set.
+      You can construct this from stored URLs without fetching:
+      `%ExAcme.Order{url: stored_url, finalize_url: stored_finalize_url}`
     - `csr` - The Certificate Signing Request (CSR) to send for finalization. You can generate a
        CSR using the `ExAcme.Order.to_csr/2` function.
     - `account_key` - The account key used for authentication.
@@ -319,14 +321,14 @@ defmodule ExAcme do
     - `{:retry_after, seconds}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the finalization process.
   """
-  @spec finalize_order(String.t(), X509.CSR.t(), ExAcme.AccountKey.t(), client()) ::
+  @spec finalize_order(ExAcme.Order.t(), X509.CSR.t(), ExAcme.AccountKey.t(), client()) ::
           {:ok, ExAcme.Order.t()} | {:retry_after, non_neg_integer()} | {:error, any()}
-  def finalize_order(finalize_url, csr, account_key, client) do
+  def finalize_order(%ExAcme.Order{url: order_url, finalize_url: finalize_url}, csr, account_key, client) do
     csr = csr |> X509.CSR.to_der() |> Base.url_encode64(padding: false)
     request = ExAcme.Request.build_update(finalize_url, %{csr: csr})
 
     with {:ok, %{body: body, headers: headers}} <- ExAcme.Request.send_request(request, account_key, client) do
-      location = headers |> Map.get("location", []) |> List.first()
+      location = headers |> Map.get("location", []) |> List.first() || order_url
       {:ok, ExAcme.Order.from_response(location, body)}
     end
   end
@@ -459,7 +461,7 @@ defmodule ExAcme do
   end
 
   @doc """
-  Starts the validation process for a challenge by sending a request to the specified challenge URL.
+  Starts the validation process for a challenge.
 
   This function notifies the ACME server that the client is ready for the server to attempt validation
   of the challenge. The server will then verify that the requirements of the challenge have been
@@ -467,7 +469,9 @@ defmodule ExAcme do
 
   ## Parameters
 
-    - `url` - The URL of the challenge to validate.
+    - `challenge` - The `ExAcme.Challenge` struct to validate. Must have `url` field set.
+      You can construct this from a stored URL without fetching:
+      `%ExAcme.Challenge{url: stored_url}`
     - `account_key` - The account key used for authentication.
     - `client` - The pid or name of the ExAcme client agent.
 
@@ -478,9 +482,9 @@ defmodule ExAcme do
     - `{:retry_after, seconds}` - If the server returns a Retry-After header.
     - `{:error, reason}` - If an error occurs during the validation request.
   """
-  @spec start_challenge_validation(String.t(), ExAcme.AccountKey.t(), client()) ::
+  @spec start_challenge_validation(ExAcme.Challenge.t(), ExAcme.AccountKey.t(), client()) ::
           {:ok, ExAcme.Challenge.t()} | {:retry_after, non_neg_integer()} | {:error, any()}
-  def start_challenge_validation(url, account_key, client) do
+  def start_challenge_validation(%ExAcme.Challenge{url: url}, account_key, client) do
     request = ExAcme.Request.build_update(url, %{})
 
     with {:ok, %{body: body}} <- ExAcme.Request.send_request(request, account_key, client) do

--- a/test/ex_acme/certificate_test.exs
+++ b/test/ex_acme/certificate_test.exs
@@ -24,7 +24,7 @@ defmodule ExAcme.CertificateTest do
     ExAcme.TestHelpers.validate_order(order, account_key, client)
     {:ok, csr} = ExAcme.Order.to_csr(order, @private_key)
 
-    ExAcme.finalize_order(order.finalize_url, csr, account_key, client)
+    ExAcme.finalize_order(order, csr, account_key, client)
 
     assert_eventually {:ok, %{status: "valid", certificate_url: certificate_url}} =
                         ExAcme.fetch_order(order.url, account_key, client)
@@ -38,7 +38,7 @@ defmodule ExAcme.CertificateTest do
     ExAcme.TestHelpers.validate_order(order, account_key, client)
     {:ok, csr} = ExAcme.Order.to_csr(order, @private_key)
 
-    ExAcme.finalize_order(order.finalize_url, csr, account_key, client)
+    ExAcme.finalize_order(order, csr, account_key, client)
 
     assert_eventually {:ok, %{status: "valid", certificate_url: certificate_url}} =
                         ExAcme.fetch_order(order.url, account_key, client)

--- a/test/ex_acme/order_test.exs
+++ b/test/ex_acme/order_test.exs
@@ -37,9 +37,9 @@ defmodule ExAcme.OrderTest do
     ExAcme.TestHelpers.validate_order(order, account_key, client)
     {:ok, csr} = ExAcme.Order.to_csr(order, @private_key)
 
-    {:ok, finalized_order} = ExAcme.finalize_order(order.finalize_url, csr, account_key, client)
+    {:ok, finalized_order} = ExAcme.finalize_order(order, csr, account_key, client)
 
-    assert finalized_order.url == order.url or finalized_order.url == nil
+    assert finalized_order.url == order.url
 
     assert_eventually {:ok, %{status: "valid"}} =
                         ExAcme.fetch_order(order.url, account_key, client)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -40,7 +40,7 @@ defmodule ExAcme.TestHelpers do
     challenge = ExAcme.Challenge.find_by_type(authorization, "dns-01")
     %{"type" => "dns", "value" => domain_name} = authorization.identifier
     ExAcme.TestHelpers.set_dns_challenge(domain_name, challenge.token, account_key)
-    ExAcme.start_challenge_validation(challenge.url, account_key, client)
+    ExAcme.start_challenge_validation(challenge, account_key, client)
 
     eventually {:ok, %{status: "valid"}} =
                  ExAcme.fetch_challenge(challenge.url, account_key, client)
@@ -54,7 +54,7 @@ defmodule ExAcme.TestHelpers do
     private_key = X509.PrivateKey.new_ec(:secp256r1)
     {:ok, csr} = ExAcme.Order.to_csr(order, private_key)
 
-    ExAcme.finalize_order(order.finalize_url, csr, account_key, client)
+    ExAcme.finalize_order(order, csr, account_key, client)
 
     eventually {:ok, %{status: "valid", certificate_url: certificate_url}} =
                  ExAcme.fetch_order(order.url, account_key, client)


### PR DESCRIPTION
BREAKING CHANGE: `finalize_order/4` and `start_challenge_validation/3` now accept struct arguments instead of URL strings.

Before:
  ExAcme.finalize_order(order.finalize_url, csr, account_key, client)
  ExAcme.start_challenge_validation(challenge.url, account_key, client)

After:
  ExAcme.finalize_order(order, csr, account_key, client)
  ExAcme.start_challenge_validation(challenge, account_key, client)

This change:
- Aligns with idiomatic Elixir patterns (Phoenix, Ecto)
- Fixes issue where order.url could be nil when Location header missing
- Enables URL preservation without extra network calls
- Structs can be constructed from stored URLs for DB rehydration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `finalize_order` now accepts an Order object instead of a finalize URL string.
  * `start_challenge_validation` now accepts a Challenge object instead of a URL string.

* **Documentation**
  * Updated API usage examples to reflect the new method signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->